### PR TITLE
Use `once_cell` to cache the function pointer to `JAWT_GetAWT`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-quartz-core",
+ "once_cell",
  "utf16_literal",
  "windows 0.60.0",
  "x11-dl",

--- a/jawt/Cargo.toml
+++ b/jawt/Cargo.toml
@@ -23,6 +23,7 @@ euclid = { version = "0.22", optional = true, default-features = false, features
 jawt-sys = { version = "0.1", path = "../jawt-sys", default-features = false }
 jni = { workspace = true }
 libc = { version = "0.2", default-features = false }
+once_cell = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { workspace = true, features = [


### PR DESCRIPTION
Replaced the unsafe manual implementation of caching the found `JAWT_GetAWT` in `jawt` with the one using `once_cell`.